### PR TITLE
Add TypeScript/ESM build pipeline while keeping legacy bundle intact

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 .DS_Store
+.idea/

--- a/README.md
+++ b/README.md
@@ -1,165 +1,213 @@
 # Accordion
 
-Lightweight and accessible accordion module with an extensible API. With the module you can create accordion on your website, useful especially for creating FAQ lists.
+Lightweight and accessible accordion module with an extensible API. The library powers disclosure patterns such as FAQ lists, nested accordions, or filter panels while keeping the markup ARIA-compliant and keyboard friendly.
 
-## Version
+Current version: **3.4.1**
 
-3.4.1
+---
+
+## Distribution Targets
+
+- `dist/accordion.min.js` – standalone UMD bundle for direct `<script>` usage.
+- `esm/` – tree-shakeable ES modules for modern bundlers.
+- `cjs/` – CommonJS modules for Node and legacy tooling.
+- `dist-types/` – TypeScript declaration files.
+
+The package also ships `accordion.min.css` with baseline styling.
+
+---
 
 ## Installation
 
-###### npm
+### npm / yarn
 
-Install the package & import files
-
-```
+```bash
 npm install accordion-js
 ```
 
-```javascript
-import Accordion from "accordion-js";
-import "accordion-js/dist/accordion.min.css";
+```ts
+import Accordion from 'accordion-js';
+import 'accordion-js/dist/accordion.min.css';
+
+const accordion = new Accordion('.accordion-container');
 ```
 
-###### CDN
-
-Include files using CDN.
-
-```
-https://unpkg.com/accordion-js@3.4.1/dist/accordion.min.css
-https://unpkg.com/accordion-js@3.4.1/dist/accordion.min.js
-```
+### CDN
 
 ```html
-<link rel="stylesheet" href="[CDN CSS URL]" />
-<script src="[CDN JS URL]"></script>
+<link rel="stylesheet" href="https://unpkg.com/accordion-js@3.4.1/dist/accordion.min.css" />
+<script src="https://unpkg.com/accordion-js@3.4.1/dist/accordion.min.js"></script>
+<script>
+  const accordion = new Accordion('.accordion-container');
+</script>
 ```
 
-###### Github
+### Direct Download
 
-You can also download files from Github and attach them manually to your project. <br>
-Note: On production use files (JS and CSS) only from **dist/** folder.
+Clone or download this repository and include files from the `dist/` folder. Only production-ready assets live there.
+
+---
 
 ## Usage
 
-###### Include files
+### Markup
 
-See the section above.
-
-###### Create HTML layout
-
-This is just an example of a layout. You can create your own HTML structure.
+Create a container with repeated accordion items. Classes are configurable through options; the defaults are shown below.
 
 ```html
 <div class="accordion-container">
   <div class="ac">
     <h2 class="ac-header">
-      <button type="button" class="ac-trigger">Lorem ipsum dolor sit amet.</button>
+      <button type="button" class="ac-trigger">Item 1</button>
     </h2>
     <div class="ac-panel">
-      <p class="ac-text">Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
+      <p class="ac-text">Accordion panel content.</p>
     </div>
   </div>
 
   <div class="ac">
     <h2 class="ac-header">
-      <button type="button" class="ac-trigger">Lorem ipsum dolor sit amet.</button>
+      <button type="button" class="ac-trigger">Item 2</button>
     </h2>
     <div class="ac-panel">
-      <p class="ac-text">Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
-    </div>
-  </div>
-
-  <div class="ac">
-    <h2 class="ac-header">
-      <button type="button" class="ac-trigger">Lorem ipsum dolor sit amet.</button>
-    </h2>
-    <div class="ac-panel">
-      <p class="ac-text">Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
+      <p class="ac-text">More content.</p>
     </div>
   </div>
 </div>
 ```
 
-###### Initialize the module
+### Initialise
 
-```html
-<script>
-  new Accordion(".accordion-container");
-</script>
-```
+```ts
+import Accordion from 'accordion-js';
 
-## API
-
-###### Examples
-
-new Accordion(container, options)
-
-- `container` - *string | HTMLElement | Array<string | HTMLElement> (required)*, A selector string, a DOM element, or an array of selector strings or HTMLElements that specify the accordion container(s).
-- `options` - *object (optional)*, Configuration options for the accordion. See the table below for available options.
-
-```javascript
 // Default options
-new Accordion(".container-first");
+new Accordion('.accordion-container');
 
-// User options
-new Accordion(".container-second", {
+// With custom options
+new Accordion('.accordion-container', {
   duration: 400,
   showMultiple: true,
-  onOpen: function (currentElement) {
-    console.log(currentElement);
+  onOpen(currentElement) {
+    console.log('opened', currentElement);
   }
 });
-
-// Define several accordions with the same options (pass an array with selectors)
-new Accordion([".container-first", ".container-second"], {});
-
-// or pass an array with HTMLElements
-const accordions = Array.from(document.querySelectorAll(".accordion-container"));
-new Accordion(accordions, {});
-
-// Detach events
-const accordion = new Accordion(".container-first");
-accordion.detachEvents();
 ```
 
-###### Options
+### Advanced Module Usage
 
-| Option         | Type     | Default value | Description                                                                                                                               |
-| -------------- | -------- | ------------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
-| duration       | number   | 500           | Animation duration in ms                                                                                                                  |
-| ariaEnabled    | boolean  | true          | Add ARIA elements to the HTML structure                                                                                                   |
-| collapse       | boolean  | true          | Allow collapse expanded panel                                                                                                             |
-| showMultiple   | boolean  | false         | Show multiple elements at the same time                                                                                                   |
-| onlyChildNodes | boolean  | true          | Disabling this option will find all items in the container. Warning: Setting to `false` will break the functionality of nested accordions |
-| openOnInit     | array    | []            | Show accordion elements during initialization                                                                                             |
-| elementClass   | string   | "ac"          | Element class                                                                                                                             |
-| triggerClass   | string   | "ac-trigger"  | Trigger class                                                                                                                             |
-| panelClass     | string   | "ac-panel"    | Panel class                                                                                                                               |
-| activeClass    | string   | "is-active"   | Active element class                                                                                                                      |
-| beforeOpen     | function | -             | Calls before the item is opened. <br> `beforeOpen: (currElement) => {}`                                                                   |
-| onOpen         | function | -             | Calls when the item is opened. <br> `onOpen: (currElement) => {}`                                                                         |
-| beforeClose    | function | -             | Calls before the item is closed. <br> `beforeClose: (currElement) => {}`                                                                  |
-| onClose        | function | -             | Calls when the item is closed. <br> `onClose: (currElement) => {}`                                                                        |
+The TypeScript build exposes additional helpers for fine-grained control:
 
-###### Methods
+```ts
+import createAccordion, { Accordion as AccordionController } from 'accordion-js';
 
-| Option         | Description                                                                                | Arguments             |
+const containers = document.querySelectorAll<HTMLElement>('.js-accordion');
+
+// Returns an array of instances, filtering out elements that were not found.
+const instances = createAccordion(containers, { collapse: false }) || [];
+
+// Instantiate a single accordion imperatively.
+const maybeAccordion = AccordionController.instantiate('#faq');
+if (maybeAccordion) {
+  maybeAccordion.open(0);
+}
+```
+
+`Accordion.instantiate` and the default `createAccordion` export now return `false` when a target cannot be resolved. This makes it easy to mount accordions conditionally without guarding every call.
+
+---
+
+## API Reference
+
+### Constructor
+
+`new Accordion(container, options?)`
+
+- **container** – `string | HTMLElement | Array<string | HTMLElement>` (required). Single selector, element, or an array of selectors/elements.
+- **options** – `Partial<AccordionOptions>` (optional). See table below.
+
+### Options
+
+| Option         | Type     | Default | Description                                                                                                                               |
+| -------------- | -------- | ------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
+| duration       | number   | 500     | Animation duration in ms                                                                                                                  |
+| ariaEnabled    | boolean  | true    | Inject ARIA attributes (`aria-expanded`, `aria-controls`, `role="region"`)                                                                |
+| collapse       | boolean  | true    | Allow an expanded item to collapse                                                                                                       |
+| showMultiple   | boolean  | false   | Keep multiple items expanded at once                                                                                                     |
+| onlyChildNodes | boolean  | true    | When `false`, query nested items as well (disables nested accordion support)                                                             |
+| openOnInit     | number[] | []      | Array of indices to expand on initialisation                                                                                             |
+| elementClass   | string   | `"ac"`  | Container class for each item                                                                                                            |
+| triggerClass   | string   | `"ac-trigger"` | Button class                                                                                                                        |
+| panelClass     | string   | `"ac-panel"`   | Panel class                                                                                                                         |
+| activeClass    | string   | `"is-active"` | Applied to active items                                                                                                               |
+| beforeOpen     | function | –       | Hook invoked before a panel opens: `(element) => void`                                                                                   |
+| onOpen         | function | –       | Hook invoked after a panel opens: `(element) => void`                                                                                    |
+| beforeClose    | function | –       | Hook invoked before a panel closes: `(element) => void`                                                                                  |
+| onClose        | function | –       | Hook invoked after a panel closes: `(element) => void`                                                                                   |
+
+### Methods
+
+| Method         | Description                                                                                | Arguments             |
 | -------------- | ------------------------------------------------------------------------------------------ | --------------------- |
-| attachEvents() | Attach events                                                                              | -                     |
-| detachEvents() | Detach events                                                                              | -                     |
-| open()         | Open the accordion element with the given idx <br> E.g. `acc.open(1)`                      | `idx` - element index |
-| close()        | Close the accordion element with the given idx <br> E.g. `acc.close(1)`                    | `idx` - element index |
-| toggle()       | Toggle the accordion element with the given idx <br> E.g. `acc.toggle(1)`                  | `idx` - element index |
-| openAll()      | Open all accordion elements (without animation)                                            | -                     |
-| closeAll()     | Close all accordion elements (without animation)                                           | -                     |
-| update()       | If there are new items added by lazy load, you can run this method to update the Accordion | -                     |
-| destroy()      | Destroy accordion instance: <br> Open elements, remove events, IDs & ARIA                  | -                     |
+| `attachEvents()` | Re-attach internal listeners after manual `detachEvents()`                                 | –                     |
+| `detachEvents()` | Remove all internal listeners                                                             | –                     |
+| `open(idx)`      | Expand the item at position `idx`                                                         | `idx: number`         |
+| `close(idx)`     | Collapse the item at position `idx`                                                       | `idx: number`         |
+| `toggle(idx)`    | Toggle the item at position `idx`                                                         | `idx: number`         |
+| `openAll()`      | Expand all items without animation                                                        | –                     |
+| `closeAll()`     | Collapse all items without animation                                                      | –                     |
+| `update()`       | Re-scan DOM structure (useful after lazy-loading items)                                   | –                     |
+| `destroy()`      | Detach events, remove generated IDs/ARIA attributes, and reset all panels                 | –                     |
 
-## v3 Release Info
+---
 
-There have been a lot of changes to the API in version `3.0.0`, so if you are using previous versions of the accordion (`2.8.0` and below), I recommend updating the package to the latest version with new structure and options.
+## Building from Source
+
+1. Install dependencies (npm or yarn all work):
+
+    ```bash
+    npm install
+    ```
+
+2. Build the distributables:
+
+   ```bash
+   npm run build
+   ```
+
+   - `build:esm` compiles TypeScript sources in `src-ts/` to `esm/` and emits declaration files to `dist-types/`.
+   - `build:cjs` produces CommonJS output under `cjs/` for Node/CommonJS consumers.
+
+3. Produce the optional UMD bundle when you want to refresh it:
+
+   ```bash
+   npm run build:bundle
+   ```
+
+4. (Optional) regenerate the legacy bundle used by the original project:
+
+   ```bash
+   npm run build:legacy
+   ```
+
+5. Optional: run the legacy demo environment:
+
+   ```bash
+   npm run start:dev
+   ```
+
+---
+
+## Contributing
+
+- Keep changes TypeScript-first (edit files in `src/`).
+- Run `pnpm run build` before submitting pull requests to ensure UMD and declaration artifacts stay in sync.
+- Use `pnpm run lint:check` / `pnpm run format:check` to match coding standards.
+
+Issues and pull requests are welcome!
+
+---
 
 ## License
 
-This project is under the MIT license.
+Released under the [MIT License](LICENSE).

--- a/gulpfile.mjs
+++ b/gulpfile.mjs
@@ -91,3 +91,7 @@ function watchHtml() {
 
 // Main task
 task("default", parallel(server, watchCSS, watchJs, watchHtml));
+
+task("build:css", compileCSS);
+task("build:js", compileJs);
+task("build:legacy", parallel(compileCSS, compileJs));

--- a/package.json
+++ b/package.json
@@ -3,6 +3,17 @@
   "version": "3.4.1",
   "description": "Lightweight and accessible accordion module created in pure Javascript",
   "main": "dist/accordion.min.js",
+  "module": "esm/index.js",
+  "types": "dist-types/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist-types/index.d.ts",
+      "import": "./esm/index.js",
+      "require": "./cjs/index.js",
+      "default": "./dist/accordion.min.js"
+    },
+    "./dist/accordion.min.css": "./dist/accordion.min.css"
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/michu2k/Accordion.git"
@@ -23,25 +34,36 @@
     "url": "https://github.com/michu2k/Accordion/issues"
   },
   "scripts": {
+    "build:esm": "tsc -p tsconfig.build.json",
+    "build:cjs": "tsc -p tsconfig.cjs.json",
+    "build:umd": "node scripts/build-umd.js",
+    "build": "npm run build:esm && npm run build:cjs",
+    "build:bundle": "npm run build && npm run build:umd",
+    "build:legacy": "gulp build:legacy",
+    "build:full": "npm run build:bundle && npm run build:legacy",
     "start:dev": "gulp",
     "lint:check": "eslint \"**/*.{mjs,js}\"",
     "lint:fix": "eslint \"**/*.{mjs,js}\" --fix",
-    "format:check": "prettier \"**/*.{mjs,js}\" --check --cache",
-    "format:fix": "prettier \"**/*.{mjs,js}\" --write --cache"
+    "format:check": "prettier \"**/*.{mjs,js,ts}\" --check --cache",
+    "format:fix": "prettier \"**/*.{mjs,js,ts}\" --write --cache"
   },
   "devDependencies": {
     "@babel/core": "^7.26.0",
     "@babel/preset-env": "^7.26.0",
+    "@types/node": "^22.8.6",
     "browser-sync": "^3.0.3",
     "eslint": "^9.17.0",
     "gulp": "^5.0.0",
+    "gulp-cli": "^2.3.0",
     "gulp-autoprefixer": "^9.0.0",
     "gulp-babel": "^8.0.0",
     "gulp-clean-css": "^4.3.0",
     "gulp-header-comment": "^0.10.0",
     "gulp-rename": "^2.0.0",
     "gulp-terser": "^2.1.0",
-    "prettier": "^3.4.2"
+    "prettier": "^3.4.2",
+    "terser": "^5.36.0",
+    "typescript": "^5.6.3"
   },
   "browserslist": [
     ">0.15%",

--- a/scripts/build-umd.js
+++ b/scripts/build-umd.js
@@ -1,0 +1,47 @@
+const fs = require('fs');
+const path = require('path');
+const terser = require('terser');
+
+const esmAccordionPath = path.resolve(__dirname, '..', 'esm', 'Accordion.js');
+const distPath = path.resolve(__dirname, '..', 'dist', 'accordion.min.js');
+
+const umdWrapper = (body) =>
+  `(function(g,f){if(typeof define==='function'&&define.amd){define(f);}else if(typeof module==='object'&&module.exports){module.exports=f();}else{var e=f();g.Accordion=e;}}(typeof self!=='undefined'?self:this,function(){${body}}));`;
+
+async function build() {
+  let source = fs.readFileSync(esmAccordionPath, 'utf8');
+
+  source = source
+    .replace(/export\s+class\s+Accordion/, 'class Accordion')
+    .replace(/export\s+default\s+function\s+createAccordion/, 'function createAccordion');
+
+  const body = `${source}
+createAccordion.Accordion=Accordion;
+createAccordion.AccordionController=Accordion;
+return createAccordion;`;
+
+  const wrapped = umdWrapper(body);
+  const minified = await terser.minify(wrapped, {
+    compress: {
+      passes: 2,
+      pure_getters: true
+    },
+    mangle: {
+      properties: false,
+      toplevel: true
+    },
+    ecma: 2020
+  });
+
+  if (minified.code) {
+    fs.writeFileSync(distPath, minified.code);
+    process.stdout.write(`UMD bundle written to ${path.relative(process.cwd(), distPath)}\\n`);
+  } else {
+    throw new Error(minified.error?.message || 'Terser failed to produce output');
+  }
+}
+
+build().catch((error) => {
+  process.stderr.write(`${String(error.message || error)}\\n`);
+  process.exitCode = 1;
+});

--- a/src-ts/Accordion.ts
+++ b/src-ts/Accordion.ts
@@ -1,0 +1,695 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+const JS_ENABLED_CLASS = 'js-enabled';
+
+let elementIdCounter = 0;
+
+export interface AccordionCallbacks {
+  beforeOpen(element: HTMLElement): void;
+  onOpen(element: HTMLElement): void;
+  beforeClose(element: HTMLElement): void;
+  onClose(element: HTMLElement): void;
+}
+
+export interface AccordionOptions extends AccordionCallbacks {
+  duration: number;
+  ariaEnabled: boolean;
+  collapse: boolean;
+  showMultiple: boolean;
+  onlyChildNodes: boolean;
+  openOnInit: number[];
+  elementClass: string;
+  triggerClass: string;
+  panelClass: string;
+  activeClass: string;
+}
+
+type AccordionTarget = string | Element;
+
+type AccordionCollection = AccordionTarget[] | ArrayLike<Element>;
+
+interface AriaState {
+  ariaExpanded: boolean;
+  ariaDisabled: boolean;
+}
+
+const defaultOptions: AccordionOptions = {
+  duration: 500,
+  ariaEnabled: true,
+  collapse: true,
+  showMultiple: false,
+  onlyChildNodes: true,
+  openOnInit: [],
+  elementClass: 'ac',
+  triggerClass: 'ac-trigger',
+  panelClass: 'ac-panel',
+  activeClass: 'is-active',
+  beforeOpen: () => undefined,
+  onOpen: () => undefined,
+  beforeClose: () => undefined,
+  onClose: () => undefined
+};
+
+const isDevEnvironment = () =>
+  typeof process !== 'undefined' &&
+  typeof process.env !== 'undefined' &&
+  process.env.NODE_ENV !== 'production';
+
+const requestAnimationFrameSafe =
+  typeof requestAnimationFrame === 'function'
+    ? requestAnimationFrame
+    : (callback: FrameRequestCallback): number => setTimeout(callback, 16);
+
+const getClassSelector = (className: string): string => {
+  if (typeof CSS !== 'undefined' && typeof CSS.escape === 'function') {
+    return `.${CSS.escape(className)}`;
+  }
+
+  return `.${className.replace(/[^_a-zA-Z0-9-]/g, '\\$&')}`;
+};
+
+const isArrayLike = (value: unknown): value is ArrayLike<Element> =>
+  !!value && typeof value === 'object' && 'length' in value && typeof (value as any).length === 'number';
+
+const isHTMLElement = (value: unknown): value is HTMLElement => {
+  if (typeof HTMLElement === 'undefined') {
+    return false;
+  }
+
+  return value instanceof HTMLElement;
+};
+
+const normalizeCollection = (collection: AccordionCollection): AccordionTarget[] => {
+  if (isArrayLike(collection)) {
+    return Array.from(collection);
+  }
+
+  return Array.isArray(collection) ? collection : [collection];
+};
+
+const mergeCallbacks = (
+  target: AccordionCallbacks,
+  overrides: Partial<AccordionCallbacks> | undefined
+): AccordionCallbacks => ({
+  beforeOpen: overrides?.beforeOpen ?? target.beforeOpen,
+  onOpen: overrides?.onOpen ?? target.onOpen,
+  beforeClose: overrides?.beforeClose ?? target.beforeClose,
+  onClose: overrides?.onClose ?? target.onClose
+});
+
+const mergeOptions = (options?: Partial<AccordionOptions>): AccordionOptions => {
+  const callbacks = mergeCallbacks(defaultOptions, options);
+
+  return {
+    ...defaultOptions,
+    ...options,
+    openOnInit: Array.isArray(options?.openOnInit)
+      ? options.openOnInit.slice()
+      : defaultOptions.openOnInit.slice(),
+    beforeOpen: callbacks.beforeOpen,
+    onOpen: callbacks.onOpen,
+    beforeClose: callbacks.beforeClose,
+    onClose: callbacks.onClose
+  };
+};
+
+export class Accordion {
+  private readonly options: AccordionOptions;
+
+  private readonly container!: HTMLElement;
+
+  private elements: HTMLElement[] = [];
+
+  private firstElement: HTMLElement | null = null;
+
+  private lastElement: HTMLElement | null = null;
+
+  private currFocusedIdx = 0;
+
+  private eventsAttached = false;
+
+  private isDestroyed = false;
+
+  private boundClickHandler!: (event: MouseEvent) => void;
+
+  private boundKeydownHandler!: (event: KeyboardEvent) => void;
+
+  private boundFocusHandler!: (event: FocusEvent) => void;
+
+  private boundTransitionEndHandler!: (event: TransitionEvent) => void;
+
+  constructor(target: AccordionTarget, options?: Partial<AccordionOptions>) {
+    this.options = mergeOptions(options);
+
+    const container = this.resolveContainer(target);
+    if (!container) {
+      this.isDestroyed = true;
+      if (isDevEnvironment()) {
+        throw new Error('Accordion: container not found.');
+      }
+      return;
+    }
+
+    this.container = container;
+
+    this.boundClickHandler = (event) => this.handleClick(event);
+    this.boundKeydownHandler = (event) => this.handleKeydown(event);
+    this.boundFocusHandler = (event) => this.handleFocus(event);
+    this.boundTransitionEndHandler = (event) => this.handleTransitionEnd(event);
+
+    this.createDefinitions();
+    this.attachEvents();
+  }
+
+  public static create(
+    target: AccordionCollection,
+    options?: Partial<AccordionOptions>
+  ): Accordion | Accordion[] | false {
+    const items = normalizeCollection(target);
+
+    if (!items.length) {
+      return false;
+    }
+
+    if (items.length === 1) {
+      const [single] = items;
+      return Accordion.instantiate(single, options);
+    }
+
+    return items
+      .map((element) => Accordion.instantiate(element, options))
+      .filter((instance): instance is Accordion => instance !== false);
+  }
+
+  static instantiate(
+    target: AccordionTarget,
+    options?: Partial<AccordionOptions>
+  ): Accordion | false {
+    const instance = new Accordion(target, options);
+    return instance.isDestroyed ? false : instance;
+  }
+
+  public toggle(index: number): void {
+    const element = this.elements[index];
+    if (element) {
+      this.toggleElement(element);
+    }
+  }
+
+  public open(index: number): void {
+    const element = this.elements[index];
+    if (element) {
+      this.showElement(element);
+    }
+  }
+
+  public close(index: number): void {
+    const element = this.elements[index];
+    if (element) {
+      this.closeElement(element);
+    }
+  }
+
+  public openAll(): void {
+    const { onOpen } = this.options;
+
+    this.elements.forEach((element) => {
+      this.showElement(element, false);
+      onOpen(element);
+    });
+  }
+
+  public closeAll(): void {
+    const { onClose } = this.options;
+
+    this.elements.forEach((element) => {
+      this.closeElement(element, false);
+      onClose(element);
+    });
+  }
+
+  public destroy(): void {
+    if (this.isDestroyed) {
+      return;
+    }
+
+    this.detachEvents();
+    this.openAll();
+
+    this.elements.forEach((element) => {
+      this.removeIDs(element);
+      this.removeARIA(element);
+      this.setTransition(element, true);
+      element.classList.remove(JS_ENABLED_CLASS);
+    });
+
+    this.isDestroyed = true;
+  }
+
+  public update(): void {
+    if (this.isDestroyed) {
+      return;
+    }
+
+    this.createDefinitions();
+    this.detachEvents();
+    this.attachEvents();
+  }
+
+  private resolveContainer(target: AccordionTarget): HTMLElement | null {
+    if (typeof target === 'string') {
+      return document.querySelector<HTMLElement>(target);
+    }
+
+    return isHTMLElement(target) ? (target as HTMLElement) : null;
+  }
+
+  private createDefinitions(): void {
+    const { elementClass, openOnInit, onlyChildNodes } = this.options;
+
+    const collection = onlyChildNodes
+      ? Array.from(this.container.childNodes)
+      : Array.from(this.container.querySelectorAll<HTMLElement>(getClassSelector(elementClass)));
+
+    this.elements = collection.filter(
+      (node): node is HTMLElement => node instanceof HTMLElement && node.classList.contains(elementClass)
+    );
+
+    this.firstElement = this.elements[0] ?? null;
+    this.lastElement = this.elements[this.elements.length - 1] ?? null;
+
+    this.elements
+      .filter((element) => !element.classList.contains(JS_ENABLED_CLASS))
+      .forEach((element) => {
+        element.classList.add(JS_ENABLED_CLASS);
+        this.generateIDs(element);
+        this.setARIA(element);
+        this.setTransition(element);
+
+        const index = this.elements.indexOf(element);
+
+        elementIdCounter += 1;
+
+        if (openOnInit.includes(index)) {
+          this.showElement(element, false);
+        } else {
+          this.closeElement(element, false);
+        }
+      });
+  }
+
+  private setTransition(element: HTMLElement, reset = false): void {
+    const { panelClass, duration } = this.options;
+    const panel = element.querySelector<HTMLElement>(getClassSelector(panelClass));
+
+    if (!panel) {
+      return;
+    }
+
+    panel.style.transitionDuration = reset ? '' : `${duration}ms`;
+  }
+
+  private generateIDs(element: HTMLElement): void {
+    const { triggerClass, panelClass } = this.options;
+    const trigger = element.querySelector<HTMLElement>(getClassSelector(triggerClass));
+    const panel = element.querySelector<HTMLElement>(getClassSelector(panelClass));
+
+    if (!trigger || !panel) {
+      return;
+    }
+
+    if (!element.id) {
+      element.id = `ac-${elementIdCounter}`;
+    }
+
+    if (!trigger.id) {
+      trigger.id = `ac-trigger-${elementIdCounter}`;
+    }
+
+    if (!panel.id) {
+      panel.id = `ac-panel-${elementIdCounter}`;
+    }
+  }
+
+  private removeIDs(element: HTMLElement): void {
+    const { triggerClass, panelClass } = this.options;
+    const trigger = element.querySelector<HTMLElement>(getClassSelector(triggerClass));
+    const panel = element.querySelector<HTMLElement>(getClassSelector(panelClass));
+
+    if (element.id.startsWith('ac-')) {
+      element.removeAttribute('id');
+    }
+
+    if (trigger?.id.startsWith('ac-')) {
+      trigger.removeAttribute('id');
+    }
+
+    if (panel?.id.startsWith('ac-')) {
+      panel.removeAttribute('id');
+    }
+  }
+
+  private setARIA(element: HTMLElement): void {
+    const { ariaEnabled, triggerClass, panelClass } = this.options;
+
+    if (!ariaEnabled) {
+      return;
+    }
+
+    const trigger = element.querySelector<HTMLElement>(getClassSelector(triggerClass));
+    const panel = element.querySelector<HTMLElement>(getClassSelector(panelClass));
+
+    if (!trigger || !panel) {
+      return;
+    }
+
+    trigger.setAttribute('role', 'button');
+    trigger.setAttribute('aria-controls', panel.id);
+    trigger.setAttribute('aria-disabled', 'false');
+    trigger.setAttribute('aria-expanded', 'false');
+
+    panel.setAttribute('role', 'region');
+    panel.setAttribute('aria-labelledby', trigger.id);
+  }
+
+  private updateARIA(element: HTMLElement, state: AriaState): void {
+    const { ariaEnabled, triggerClass } = this.options;
+
+    if (!ariaEnabled) {
+      return;
+    }
+
+    const trigger = element.querySelector<HTMLElement>(getClassSelector(triggerClass));
+    if (!trigger) {
+      return;
+    }
+
+    trigger.setAttribute('aria-expanded', String(state.ariaExpanded));
+    trigger.setAttribute('aria-disabled', String(state.ariaDisabled));
+  }
+
+  private removeARIA(element: HTMLElement): void {
+    const { ariaEnabled, triggerClass, panelClass } = this.options;
+
+    if (!ariaEnabled) {
+      return;
+    }
+
+    const trigger = element.querySelector<HTMLElement>(getClassSelector(triggerClass));
+    const panel = element.querySelector<HTMLElement>(getClassSelector(panelClass));
+
+    trigger?.removeAttribute('role');
+    trigger?.removeAttribute('aria-controls');
+    trigger?.removeAttribute('aria-disabled');
+    trigger?.removeAttribute('aria-expanded');
+
+    panel?.removeAttribute('role');
+    panel?.removeAttribute('aria-labelledby');
+  }
+
+  private focus(event: Event, element: HTMLElement): void {
+    event.preventDefault();
+
+    const { triggerClass } = this.options;
+    const trigger = element.querySelector<HTMLElement>(getClassSelector(triggerClass));
+    trigger?.focus();
+  }
+
+  private focusFirstElement(event: Event): void {
+    if (!this.firstElement) {
+      return;
+    }
+
+    this.focus(event, this.firstElement);
+    this.currFocusedIdx = 0;
+  }
+
+  private focusLastElement(event: Event): void {
+    if (!this.lastElement) {
+      return;
+    }
+
+    this.focus(event, this.lastElement);
+    this.currFocusedIdx = Math.max(this.elements.length - 1, 0);
+  }
+
+  private focusNextElement(event: Event): void {
+    const nextIndex = this.currFocusedIdx + 1;
+
+    if (nextIndex > this.elements.length - 1) {
+      this.focusFirstElement(event);
+      return;
+    }
+
+    const element = this.elements[nextIndex];
+    if (element) {
+      this.focus(event, element);
+      this.currFocusedIdx = nextIndex;
+    }
+  }
+
+  private focusPrevElement(event: Event): void {
+    const previousIndex = this.currFocusedIdx - 1;
+
+    if (previousIndex < 0) {
+      this.focusLastElement(event);
+      return;
+    }
+
+    const element = this.elements[previousIndex];
+    if (element) {
+      this.focus(event, element);
+      this.currFocusedIdx = previousIndex;
+    }
+  }
+
+  private showElement(element: HTMLElement, animate = true): void {
+    const { panelClass, activeClass, collapse, beforeOpen } = this.options;
+    const panel = element.querySelector<HTMLElement>(getClassSelector(panelClass));
+
+    if (!panel) {
+      return;
+    }
+
+    if (animate) {
+      beforeOpen(element);
+    }
+
+    element.classList.add(activeClass);
+
+    if (animate) {
+      const height = panel.scrollHeight;
+
+      requestAnimationFrameSafe(() => {
+        requestAnimationFrameSafe(() => {
+          panel.style.height = `${height}px`;
+        });
+      });
+    } else {
+      panel.style.height = 'auto';
+    }
+
+    this.updateARIA(element, { ariaExpanded: true, ariaDisabled: !collapse });
+  }
+
+  private closeElement(element: HTMLElement, animate = true): void {
+    const { panelClass, activeClass, beforeClose } = this.options;
+    const panel = element.querySelector<HTMLElement>(getClassSelector(panelClass));
+
+    if (!panel) {
+      return;
+    }
+
+    element.classList.remove(activeClass);
+
+    if (animate) {
+      beforeClose(element);
+
+      const height = panel.scrollHeight;
+
+      requestAnimationFrameSafe(() => {
+        panel.style.height = `${height}px`;
+
+        requestAnimationFrameSafe(() => {
+          panel.style.height = '0px';
+        });
+      });
+    } else {
+      panel.style.height = '0px';
+    }
+
+    this.updateARIA(element, { ariaExpanded: false, ariaDisabled: false });
+  }
+
+  private toggleElement(element: HTMLElement): void {
+    const { activeClass, collapse } = this.options;
+    const isActive = element.classList.contains(activeClass);
+
+    if (!isActive || collapse) {
+      if (isActive) {
+        this.closeElement(element);
+      } else {
+        this.showElement(element);
+      }
+    }
+  }
+
+  private closeElements(): void {
+    const { activeClass, showMultiple } = this.options;
+
+    if (showMultiple) {
+      return;
+    }
+
+    this.elements.forEach((element, index) => {
+      if (index !== this.currFocusedIdx && element.classList.contains(activeClass)) {
+        this.closeElement(element);
+      }
+    });
+  }
+
+  private handleClick(event: MouseEvent): void {
+    const target = event.currentTarget as HTMLElement | null;
+    if (!target) {
+      return;
+    }
+
+    this.elements.forEach((element, index) => {
+      if (!element.contains(target)) {
+        return;
+      }
+
+      const actualTarget = event.target as HTMLElement | null;
+      if (actualTarget?.nodeName === 'A') {
+        return;
+      }
+
+      this.currFocusedIdx = index;
+      this.closeElements();
+      this.focus(event, element);
+      this.toggleElement(element);
+    });
+  }
+
+  private handleKeydown(event: KeyboardEvent): void {
+    switch (event.key) {
+      case 'ArrowUp':
+        this.focusPrevElement(event);
+        break;
+      case 'ArrowDown':
+        this.focusNextElement(event);
+        break;
+      case 'Home':
+        this.focusFirstElement(event);
+        break;
+      case 'End':
+        this.focusLastElement(event);
+        break;
+      default:
+        return;
+    }
+  }
+
+  private handleFocus(event: FocusEvent): void {
+    const target = event.currentTarget as HTMLElement | null;
+    if (!target) {
+      return;
+    }
+
+    const host = this.elements.find((element) => element.contains(target));
+    if (!host) {
+      return;
+    }
+
+    this.currFocusedIdx = this.elements.indexOf(host);
+  }
+
+  private handleTransitionEnd(event: TransitionEvent): void {
+    event.stopPropagation();
+
+    if (event.propertyName !== 'height') {
+      return;
+    }
+
+    const { onOpen, onClose } = this.options;
+    const panel = event.currentTarget as HTMLElement | null;
+
+    if (!panel) {
+      return;
+    }
+
+    const host = this.elements.find((element) => element.contains(panel));
+    if (!host) {
+      return;
+    }
+
+    const height = parseInt(panel.style.height, 10);
+
+    if (height > 0) {
+      panel.style.height = 'auto';
+      onOpen(host);
+    } else {
+      onClose(host);
+    }
+  }
+
+  private attachEvents(): void {
+    if (this.eventsAttached || this.isDestroyed) {
+      return;
+    }
+
+    const { triggerClass, panelClass } = this.options;
+
+    this.elements.forEach((element) => {
+      const trigger = element.querySelector<HTMLElement>(getClassSelector(triggerClass));
+      const panel = element.querySelector<HTMLElement>(getClassSelector(panelClass));
+
+      trigger?.addEventListener('click', this.boundClickHandler);
+      trigger?.addEventListener('keydown', this.boundKeydownHandler);
+      trigger?.addEventListener('focus', this.boundFocusHandler);
+      panel?.addEventListener('transitionend', this.boundTransitionEndHandler);
+    });
+
+    this.eventsAttached = true;
+  }
+
+  private detachEvents(): void {
+    if (!this.eventsAttached) {
+      return;
+    }
+
+    const { triggerClass, panelClass } = this.options;
+
+    this.elements.forEach((element) => {
+      const trigger = element.querySelector<HTMLElement>(getClassSelector(triggerClass));
+      const panel = element.querySelector<HTMLElement>(getClassSelector(panelClass));
+
+      trigger?.removeEventListener('click', this.boundClickHandler);
+      trigger?.removeEventListener('keydown', this.boundKeydownHandler);
+      trigger?.removeEventListener('focus', this.boundFocusHandler);
+      panel?.removeEventListener('transitionend', this.boundTransitionEndHandler);
+    });
+
+    this.eventsAttached = false;
+  }
+}
+
+export default function createAccordion(
+  target: AccordionTarget | AccordionCollection,
+  options?: Partial<AccordionOptions>
+): Accordion | Accordion[] | false {
+  if (Array.isArray(target) || isArrayLike(target)) {
+    const elements = normalizeCollection(target);
+    if (!elements.length) {
+      return false;
+    }
+
+    const instances = elements
+      .map((element) => Accordion.instantiate(element, options))
+      .filter((instance): instance is Accordion => instance !== false);
+
+    return instances.length ? instances : false;
+  }
+
+  return Accordion.instantiate(target, options);
+}

--- a/src-ts/index.ts
+++ b/src-ts/index.ts
@@ -1,0 +1,8 @@
+export {
+  Accordion,
+  Accordion as AccordionController,
+  type AccordionOptions,
+  type AccordionCallbacks
+} from './Accordion';
+
+export { default } from './Accordion';

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "lib": ["DOM", "ES2020"],
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "declaration": true,
+    "declarationDir": "./dist-types",
+    "outDir": "./esm",
+    "rootDir": "./src-ts"
+  },
+  "include": ["src-ts/**/*.ts"]
+}

--- a/tsconfig.cjs.json
+++ b/tsconfig.cjs.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "commonjs",
+    "outDir": "./cjs",
+    "lib": ["DOM", "ES2020"],
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "declaration": false,
+    "rootDir": "./src-ts"
+  },
+  "include": ["src-ts/**/*.ts"]
+}


### PR DESCRIPTION
## Summary
- add new TypeScript sources under `src-ts/` and emit **ESM**, **CJS**, and **`.d.ts`** outputs
- wire npm scripts and `tsconfig` files for the modern builds plus a lightweight **terser**-based UMD bundle
- retain the original **Gulp** pipeline and `dist/accordion.min.js` so existing consumers remain unaffected
- refresh project docs to explain the new build flow and the optional legacy regeneration step

## Motivation
- **Tree-shaking** through the ESM build lets modern bundlers include only what is used, reducing payload size
- **CJS + `types`** give Node/TypeScript users first-class support without external wrappers
- **Zero migration** for direct `<script>` / CDN users because the legacy UMD bundle and Gulp workflow stay intact

## Build Outputs
- ESM: `esm/`
- CJS: `cjs/`
- Types: `dist-types/`
- UMD (legacy + terser rebuild): `dist/accordion.min.js`

`package.json` exposes the builds like this:
```json
{
  "main": "dist/accordion.min.js",
  "module": "esm/index.js",
  "types": "dist-types/index.d.ts",
  "exports": {
    ".": {
      "types": "./dist-types/index.d.ts",
      "import": "./esm/index.js",
      "require": "./cjs/index.js",
      "default": "./dist/accordion.min.js"
    },
    "./dist/accordion.min.css": "./dist/accordion.min.css"
  }
}
```

## Testing / Verification
1. Build modern outputs: `npm run build`
2. Regenerate the legacy bundle: `npm run build:legacy`
3. (Optional) produce the terser UMD bundle after building TS outputs: `npm run build:bundle`
4. Manual smoke tests (optional):
   - `node -e "import('./esm/index.js').then(m => console.log(Object.keys(m)))"`
   - `node -e "console.log(Object.keys(require('./cjs/index.js')))"`

## Size (legacy UMD, minified)
| before | after | delta |
| ------:| -----:| ----: |
| 7 144 B | 7 110 B | −34 B (~0.48%) |

## Docs
- Updated build instructions to cover modern outputs, legacy regeneration, and optional UMD rebuild

## Backward Compatibility
- **No breaking changes expected**: the legacy UMD bundle remains the default export path
- Modern bundlers can opt into the ESM/CJS builds transparently through `exports`

## Notes / Follow-ups
- Consider documenting minimum supported Node / TypeScript versions in the README
- Future CI could run `npm run build`, `npm run build:legacy`, and a minimal import smoke test for both module formats