### PR TITLE
fix for anchor element without href

### DIFF
--- a/src/accordion.js
+++ b/src/accordion.js
@@ -334,7 +334,7 @@
         const target = e.currentTarget;
 
         this.elements.forEach((element, idx) => {
-          if (element.contains(target) && e.target.nodeName !== "A") {
+          if (element.contains(target) && (e.target.nodeName !== "A" || e.target.nodeName === "A" && !e.target.hasAttribute('href'))) {
             this.currFocusedIdx = idx;
 
             this.closeElements();


### PR DESCRIPTION
Hello!

I introduced a small fix for accordion to work (open and close) when clicked element is anchor (or pseudoelement like arrow of the anchor element). Code tests if element is an anchor and if it hasn't `href` attribute, clicking is still allowed.

Anchor tag without `href` attribute is a valid case:
https://html.spec.whatwg.org/multipage/links.html#attr-hyperlink-href

This was common case for me when developing WordPress mobile menu as accordion with your library; each entry in menu in WP is anchor, parent menu elements which have children are also anchors, but without `href` attribute.